### PR TITLE
性能优化与线程安全修复

### DIFF
--- a/src/main/java/cn/smallaswater/land/commands/sub/ExpandSubCommand.java
+++ b/src/main/java/cn/smallaswater/land/commands/sub/ExpandSubCommand.java
@@ -66,7 +66,9 @@ public class ExpandSubCommand extends BaseSubCommand {
                     double money = DataTool.getLandMoney(vector) - DataTool.getLandMoney(data.getVector());
                     if(LandModule.getModule().getMoney().myMoney(commandSender.getName()) >= money){
                         LandModule.getModule().getMoney().reduceMoney(commandSender.getName(),money);
+                        LandModule.getModule().getList().removeFromChunkIndex(data);
                         data.setVector(vector);
+                        LandModule.getModule().getList().addToChunkIndex(data);
                         commandSender.sendMessage(title+language.translateString("expandNeedSuccess")
                                 .replace("%count%",i+"").replace("%name%",data.getLandName()).replace("%money%",money+""));
                         return true;

--- a/src/main/java/cn/smallaswater/land/commands/sub/ExpandSubCommand.java
+++ b/src/main/java/cn/smallaswater/land/commands/sub/ExpandSubCommand.java
@@ -45,7 +45,6 @@ public class ExpandSubCommand extends BaseSubCommand {
                 if(data != null) {
                     commandSender.sendMessage(title+language.translateString("mathLandMoney"));
                     Vector vector = newLandDataVector((Player) commandSender,i,data.getVector().clone());
-                    LandData name = DataTool.checkOverlap(vector);
                     if(data instanceof LandSubData) {
                         LandData in = DataTool.inLandAll(vector);
                         if(in != null && in.getLandName().equalsIgnoreCase(((LandSubData) data).getMasterData().getLandName())){
@@ -53,12 +52,18 @@ public class ExpandSubCommand extends BaseSubCommand {
                                 commandSender.sendMessage(title + language.translateString("notHavePermission"));
                                 return true;
                             }
+                            LandData subOverlap = DataTool.checkOverlap(vector, ((LandSubData) data).getMasterData(), data);
+                            if (subOverlap != null) {
+                                commandSender.sendMessage(title + language.translateString("playerBuyLandErrorLandInArray").replace("%name%", subOverlap.getLandName()));
+                                return true;
+                            }
                         }else{
                             commandSender.sendMessage(language.translateString("subInMaster").replace("%name%",((LandSubData) data).getMasterData().getLandName()));
                             return true;
                         }
                     }else{
-                        if (name != null && !name.equals(data)) {
+                        LandData name = DataTool.checkOverlap(vector, null, data);
+                        if (name != null) {
                             commandSender.sendMessage(title + language.translateString("playerBuyLandErrorLandInArray").replace("%name%", name.getLandName()));
                             return true;
                         }

--- a/src/main/java/cn/smallaswater/land/lands/data/LandData.java
+++ b/src/main/java/cn/smallaswater/land/lands/data/LandData.java
@@ -246,7 +246,7 @@ public class LandData  {
     }
 
     public void removeSubLand(String landName){
-        for(LandSubData data:subData){
+        for(LandSubData data : new LinkedList<>(subData)){
             if(data.getLandName().equalsIgnoreCase(landName)){
                 data.close();
             }
@@ -407,6 +407,7 @@ public class LandData  {
             return;
         }
         if(LandModule.getModule().getList().contains(this)){
+            LandModule.getModule().getList().removeFromChunkIndex(this);
             LandModule.getModule().getList().getData().remove(this);
         }
         File file = new File(LandModule.getModule().getModuleInfo().getDataFolder()+"/lands/"+landName+".yml");
@@ -443,7 +444,7 @@ public class LandData  {
 
     @Override
     public int hashCode() {
-        return getLandName().hashCode();
+        return getLandName().toLowerCase().hashCode();
     }
 
 }

--- a/src/main/java/cn/smallaswater/land/lands/data/sub/LandSubData.java
+++ b/src/main/java/cn/smallaswater/land/lands/data/sub/LandSubData.java
@@ -4,9 +4,9 @@ import cn.nukkit.Server;
 import cn.nukkit.level.Position;
 import cn.smallaswater.land.event.land.LandCloseEvent;
 import cn.smallaswater.land.lands.data.LandData;
-import cn.smallaswater.land.players.MemberSetting;
-import cn.smallaswater.land.module.LandModule;
 import cn.smallaswater.land.lands.settings.LandSetting;
+import cn.smallaswater.land.module.LandModule;
+import cn.smallaswater.land.players.MemberSetting;
 import cn.smallaswater.land.players.PlayerSetting;
 import cn.smallaswater.land.utils.Vector;
 
@@ -122,6 +122,6 @@ public class LandSubData extends LandData{
 
     @Override
     public int hashCode() {
-        return getLandName().hashCode() + masterData.hashCode();
+        return getLandName().toLowerCase().hashCode() + masterData.toLowerCase().hashCode();
     }
 }

--- a/src/main/java/cn/smallaswater/land/module/LandModule.java
+++ b/src/main/java/cn/smallaswater/land/module/LandModule.java
@@ -287,6 +287,7 @@ public class LandModule {
 
 
             landList = new LandList(sqrtLand(data));
+            landList.buildChunkIndex();
         }
         return landList;
 

--- a/src/main/java/cn/smallaswater/land/tasks/ShowParticleTask.java
+++ b/src/main/java/cn/smallaswater/land/tasks/ShowParticleTask.java
@@ -106,6 +106,17 @@ public class ShowParticleTask extends PluginTask<LandMainClass> {
             }
         }
 
+        // 粒子数量上限，超出时等间隔采样
+        int maxParticles = 2000;
+        if (posList.size() > maxParticles) {
+            ArrayList<Vector3> sampled = new ArrayList<>(maxParticles);
+            double step = (double) posList.size() / maxParticles;
+            for (int idx = 0; idx < maxParticles; idx++) {
+                sampled.add(posList.get((int) (idx * step)));
+            }
+            posList = sampled;
+        }
+
         //获取中心
         int cx = (vector.getEndX() - vector.getStartX())/2 + vector.getStartX();
         int cy = (vector.getEndY() - vector.getStartY())/2 + vector.getStartY();

--- a/src/main/java/cn/smallaswater/land/utils/DataTool.java
+++ b/src/main/java/cn/smallaswater/land/utils/DataTool.java
@@ -5,6 +5,7 @@ import cn.nukkit.Server;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Position;
 import cn.nukkit.math.Vector3;
+import cn.smallaswater.land.lands.LandList;
 import cn.smallaswater.land.lands.data.LandData;
 import cn.smallaswater.land.lands.data.sub.LandSubData;
 import cn.smallaswater.land.lands.utils.ScreenSetting;
@@ -19,6 +20,8 @@ import java.util.*;
  * @author 若水
  */
 public class DataTool {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
     private static boolean checkIt(Vector vector, LandData overlap) {
         if (vector != null && overlap != null) {
@@ -186,23 +189,20 @@ public class DataTool {
      */
     @Nullable
     public static LandData getPlayerTouchArea(Position position, boolean isMaster) {
-        if (!LandModule.getModule().getList().getData().isEmpty()) {
-            Vector vector;
-            for (LandData areaClass : LandModule.getModule().getList().getData()) {
-                if (!isMaster) {
-                    for (LandSubData subData : areaClass.getSubData()) {
-                        vector = subData.getVector().clone();
-                        vector.sort();
-                        if (isEquals(position, vector)) {
-                            return subData;
-                        }
+        if (position == null || position.level == null) return null;
+        List<LandData> candidates = LandModule.getModule().getList()
+            .getChunkLands(position.level.getFolderName(),
+                position.getFloorX() >> 4, position.getFloorZ() >> 4);
+        for (LandData areaClass : candidates) {
+            if (!isMaster) {
+                for (LandSubData subData : areaClass.getSubData()) {
+                    if (isEquals(position, subData.getVector())) {
+                        return subData;
                     }
                 }
-                vector = areaClass.getVector().clone();
-                vector.sort();
-                if (isEquals(position, vector)) {
-                    return areaClass;
-                }
+            }
+            if (isEquals(position, areaClass.getVector())) {
+                return areaClass;
             }
         }
         return null;
@@ -217,17 +217,25 @@ public class DataTool {
      */
     public static LinkedList<LandData> getAroundLandData(Position position, int size) {
         LinkedList<LandData> landDataList = new LinkedList<>();
-        for (LandData landData : LandModule.getModule().getList().getData()) {
-            Vector vector = landData.getVector().clone();
-            vector.addStartX(-size);
-            vector.addStartY(-size);
-            vector.addStartZ(-size);
-            vector.addEndX(size);
-            vector.addEndY(size);
-            vector.addEndZ(size);
-            vector.sort();
-            if (isEquals(position, vector)) {
-                landDataList.add(landData);
+        String world = position.level.getFolderName();
+        int px = position.getFloorX();
+        int py = position.getFloorY();
+        int pz = position.getFloorZ();
+        int minCX = (px - size) >> 4, maxCX = (px + size) >> 4;
+        int minCZ = (pz - size) >> 4, maxCZ = (pz + size) >> 4;
+        Set<LandData> seen = new HashSet<>();
+        LandList list = LandModule.getModule().getList();
+        for (int cx = minCX; cx <= maxCX; cx++) {
+            for (int cz = minCZ; cz <= maxCZ; cz++) {
+                for (LandData landData : list.getChunkLands(world, cx, cz)) {
+                    if (!seen.add(landData)) continue;
+                    Vector vector = landData.getVector();
+                    if (px >= vector.getStartX() - size && px <= vector.getEndX() + size
+                            && py >= vector.getStartY() - size && py <= vector.getEndY() + size
+                            && pz >= vector.getStartZ() - size && pz <= vector.getEndZ() + size) {
+                        landDataList.add(landData);
+                    }
+                }
             }
         }
         return landDataList;
@@ -353,16 +361,13 @@ public class DataTool {
     }
 
     public static String getDateToString(Date date) {
-        SimpleDateFormat lsdStrFormat = new SimpleDateFormat("yyyy-MM-dd");
-        return lsdStrFormat.format(date);
+        return DATE_FORMAT.format(date);
     }
-
 
     //转换String为Date
     public static Date getDate(String format) {
-        SimpleDateFormat lsdStrFormat = new SimpleDateFormat("yyyy-MM-dd");
         try {
-            return lsdStrFormat.parse(format);
+            return DATE_FORMAT.parse(format);
         } catch (ParseException e) {
             return null;
         }
@@ -387,7 +392,7 @@ public class DataTool {
         cal.setTime(new Date());
         long time2 = cal.getTimeInMillis();
         long betweenDays = (time2 - time1) / (1000 * 3600 * 24);
-        return Integer.parseInt(String.valueOf(betweenDays)) + 1;
+        return (int) betweenDays + 1;
     }
 
     public static String getQuery(String target) {
@@ -466,6 +471,7 @@ public class DataTool {
                             }
                         }
                     }
+                    break;
                 case 4:
                     if (screenSetting.getText().matches(DataTool.getDateToString(data.getCreateTime()))) {
                         if (screenSetting.isShowSell()) {

--- a/src/main/java/cn/smallaswater/land/utils/DataTool.java
+++ b/src/main/java/cn/smallaswater/land/utils/DataTool.java
@@ -21,7 +21,8 @@ import java.util.*;
  */
 public class DataTool {
 
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+    private static final ThreadLocal<SimpleDateFormat> DATE_FORMAT =
+        ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd"));
 
     private static boolean checkIt(Vector vector, LandData overlap) {
         if (vector != null && overlap != null) {
@@ -361,13 +362,13 @@ public class DataTool {
     }
 
     public static String getDateToString(Date date) {
-        return DATE_FORMAT.format(date);
+        return DATE_FORMAT.get().format(date);
     }
 
     //转换String为Date
     public static Date getDate(String format) {
         try {
-            return DATE_FORMAT.parse(format);
+            return DATE_FORMAT.get().parse(format);
         } catch (ParseException e) {
             return null;
         }

--- a/src/main/java/cn/smallaswater/land/utils/DataTool.java
+++ b/src/main/java/cn/smallaswater/land/utils/DataTool.java
@@ -75,16 +75,33 @@ public class DataTool {
     }
 
     public static LandData checkOverlap(Vector vector, LandData sub) {
+        return checkOverlap(vector, sub, null);
+    }
+
+    /**
+     * 检查区域重叠，支持排除指定领地（用于扩展时排除自身）
+     *
+     * @param vector  待检测区域
+     * @param sub     父领地（非null时检测子领地间重叠），null时检测主领地间重叠
+     * @param exclude 需要排除的领地（通常是正在扩展的自身）
+     */
+    public static LandData checkOverlap(Vector vector, LandData sub, LandData exclude) {
         vector = vector.clone();
         vector.sort();
         if (sub == null) {
             for (LandData overlap : LandModule.getModule().getList().getData()) {
+                if (overlap.equals(exclude)) {
+                    continue;
+                }
                 if (checkIt(vector, overlap)) {
                     return overlap;
                 }
             }
         } else {
             for (LandSubData data : sub.getSubData()) {
+                if (data.equals(exclude)) {
+                    continue;
+                }
                 if (checkIt(vector, data)) {
                     return data;
                 }

--- a/src/main/java/cn/smallaswater/land/utils/Vector.java
+++ b/src/main/java/cn/smallaswater/land/utils/Vector.java
@@ -239,6 +239,13 @@ public class Vector implements Cloneable {
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        int result = level != null ? level.getFolderName().toLowerCase().hashCode() : 0;
+        result = 31 * result + startX;
+        result = 31 * result + endX;
+        result = 31 * result + startY;
+        result = 31 * result + endY;
+        result = 31 * result + startZ;
+        result = 31 * result + endZ;
+        return result;
     }
 }


### PR DESCRIPTION
- 领地查询引入区块索引（Chunk Index），将 O(n) 全量遍历优化为按区块快速查找，大幅提升高频事件（移动、方块交互等）的处理性能
- LandListener 事件处理合并重复领地查询逻辑，单次事件只做一次领地查找；玩家仅转头时跳过移动检查
- SimpleDateFormat 改为 ThreadLocal，修复多线程下的线程安全问题
- 修复 hashCode 实现（LandData/LandSubData/Vector），使其基于实际字段而非默认引用
- 粒子渲染增加数量上限（2000），超大领地等间隔采样避免客户端卡顿
- 修复爆炸方块过滤的 ConcurrentModificationException、removeSubLand 遍历删除异常
- 修复 switch-case 缺少 break 导致的逻辑穿透问题
- 优化 betweenDays 计算，移除不必要的 String 转换